### PR TITLE
fix: add missing `IMergeTag.previewValue` property

### DIFF
--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -736,6 +736,7 @@ export type BeePluginOnCommentPayload = {
 export interface IMergeTag {
   name: string
   value: string
+  previewValue?: string
   id?: number
 }
 export interface IMergeContent {


### PR DESCRIPTION
## Description

Adds the optional `previewValue` property, as described by the [documentation for "Smart Merge Tags"](https://docs.beefree.io/smart-merge-tags/#configuring-sample-content)

## Motivation and Context

The `previewValue` property is currently missing from the type definition.

See also issue #72 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
