### PR TITLE
build: give read-all permission to forked repos

### DIFF
--- a/.github/workflows/cy.yml
+++ b/.github/workflows/cy.yml
@@ -61,7 +61,7 @@ jobs:
       
       - name: Unit tests
         run: yarn test --all --cacheDirectory .jest-cache --coverage --watchAll false
-      - uses: vebr/jest-lcov-reporter@v0.2.0
+      - uses: vebr/jest-lcov-reporter@v0.2.1
         # Print comment only on 1 build and PR
         if: matrix.node-version == '12.x' && github.event_name == 'pull_request'
         with:

--- a/.github/workflows/cy.yml
+++ b/.github/workflows/cy.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - '*'
+permissions: read-all
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cy.yml
+++ b/.github/workflows/cy.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     branches:
       - '*'
-permissions: read-all
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cy.yml
+++ b/.github/workflows/cy.yml
@@ -9,6 +9,17 @@ on:
   pull_request:
     branches:
       - '*'
+permissions:
+  actions: write
+  checks: write
+  contents: read
+  deployments: read
+  issues: read
+  packages: read
+  pull-requests: write
+  repository-projects: read
+  security-events: read
+  statuses: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Give read-all permission for GITHUB_TOKEN to forked repos

## Motivation and Context

It's currently impossible to a contributor create a PR passing the CI tests.

## Usage examples

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
