### PR TITLE
Fix/merge tags type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.8.3-beta.0](https://github.com/BEE-Plugin/Bee-plugin-official/compare/v1.8.2...v1.8.3-beta.0) (2022-08-31)
+
+
+### Bug Fixes
+
+* removed id property from IMergeTag interface ([7080dde](https://github.com/BEE-Plugin/Bee-plugin-official/commit/7080dde62731d082d064f7040912a7b777ca59e8))
+
 ### [1.8.2](https://github.com/BEE-Plugin/Bee-plugin-official/compare/v1.8.1...v1.8.2) (2022-08-04)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mailupinc/bee-plugin",
-  "version": "1.8.2",
+  "version": "1.8.3-beta.0",
   "description": "wrapper of bee-plugin",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -737,7 +737,6 @@ export interface IMergeTag {
   name: string
   value: string
   previewValue?: string
-  id?: number
 }
 export interface IMergeContent {
   name: string


### PR DESCRIPTION
## Description

This PR close the following issue https://github.com/BEE-Plugin/Bee-plugin-official/issues/72

## Motivation and Context

Types for IMergeTag don't match documentation or HTML output

## Usage examples

```js
import BeePLugin from '@mailupinc/bee-plugin'

const mergeTags: IMergeTag[] = [{
  name: 'tag 1',
  value: '[tag1]'
}, {
  name: 'tag 2',
  value: '[tag2]'
}]

const beeConfig :IBeeConfig = {
  uid: 'test1-clientside',
  autosave: 15,
  language: 'en-US',
  mergeTags,
}

const template = { page: { ... } }

const beePlugin = new BeePlugin()
beePlugin.start(beeConfig, template, '', { shared: false })
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
