### PR TITLE
Fix/issue 80 save as template type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.9.1](https://github.com/BEE-Plugin/Bee-plugin-official/compare/v1.9.0...v1.9.1) (2022-10-28)
+
+
+### Bug Fixes
+
+* changed to script onSaveAsTemplate json type, updated FileSaved cdn url ([6a40575](https://github.com/BEE-Plugin/Bee-plugin-official/commit/6a405759c3aecbb70a1d5b1bf0ffa651fa124b43))
+
 ## [1.9.0](https://github.com/BEE-Plugin/Bee-plugin-official/compare/v1.8.3...v1.9.0) (2022-09-19)
 
 ## [1.9.0-alpha.0](https://github.com/BEE-Plugin/Bee-plugin-official/compare/v1.8.3-beta.0...v1.9.0-alpha.0) (2022-09-01)

--- a/example/index.html
+++ b/example/index.html
@@ -14,7 +14,7 @@
           }
         }
     </script>
-    <script src="https://cdn.rawgit.com/eligrey/FileSaver.js/5ed507ef8aa53d8ecfea96d96bc7214cd2476fd2/FileSaver.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.0/FileSaver.min.js"></script>
     <script src="/dist/bundle.js"></script>
   </head>
   <body>

--- a/example/integration.ts
+++ b/example/integration.ts
@@ -1,11 +1,13 @@
 import Bee from '../src/index'
 import { 
+  ContentDefaults,
   IBeeConfig, IMergeContent, IMergeTag, ISpecialLink, 
   LoadWorkspaceOptions, StageDisplayOptions, StageModeOptions 
 } from '../src/types/bee';
 declare let saveAs: any;
 
-const BEE_TEMPLATE_URL = 'https://rsrc.getbee.io/api/templates/m-bee'
+// const BEE_TEMPLATE_URL = 'https://rsrc.getbee.io/api/templates/m-bee'
+const BEE_BLANK_TEMPLATE_URL = 'http://storage.googleapis.com/pre-bee-app-integration-23fc44e0713f/blank.json'
 const BEEJS_URL = 'https://app-rsrc.getbee.io/plugin/BeePlugin.js'
 const API_AUTH_URL = 'https://auth.getbee.io/apiauth'
 
@@ -85,6 +87,12 @@ function getParameterByName(name) {
   return val;
 }
 
+const contentDefaults: ContentDefaults = {
+  general: {
+    contentAreaWidth: '666px'
+  }
+}
+
 const beeConfig :IBeeConfig = {
   uid: 'test1-clientside',
   container: 'bee-plugin-container',
@@ -98,6 +106,7 @@ const beeConfig :IBeeConfig = {
   mergeTags,
   mergeContents,
   contentDialog,
+  contentDefaults,
   customAssetsOptions: {
     pendo: { // sample pendo integration
       variables: {
@@ -113,7 +122,7 @@ const beeConfig :IBeeConfig = {
   },
   onSave: (_, htmlFile) => save('newsletter-template.html', htmlFile),
   onLoad: () => console.warn('*** [integration] loading a new template... '),
-  onSaveAsTemplate: (json: Record<string, unknown>) => void save('newsletter-template.json', json),
+  onSaveAsTemplate: (json) => void save('newsletter-template.json', json),
   onAutoSave: (jsonFile) => {
     console.log(`${new Date().toISOString()} autosaving...,`, jsonFile)
     window.localStorage.setItem('newsletter.autosave', jsonFile)
@@ -193,7 +202,7 @@ const addEvents = () => {
 
 const conf = { authUrl: API_AUTH_URL, beePluginUrl: BEEJS_URL }
 beeTest.getToken(process.env.PLUGIN_CLIENT_ID!, process.env.PLUGIN_CLIENT_SECRET!, conf)
-  .then(() => fetch(new Request(BEE_TEMPLATE_URL, { method: 'GET' })))
+  .then(() => fetch(new Request(BEE_BLANK_TEMPLATE_URL, { method: 'GET' })))
   .then(res => res.json())
   .then(template => {
     const sessionId = getParameterByName('sessionId')

--- a/example/integration.ts
+++ b/example/integration.ts
@@ -6,8 +6,8 @@ import {
 } from '../src/types/bee';
 declare let saveAs: any;
 
-// const BEE_TEMPLATE_URL = 'https://rsrc.getbee.io/api/templates/m-bee'
-const BEE_BLANK_TEMPLATE_URL = 'http://storage.googleapis.com/pre-bee-app-integration-23fc44e0713f/blank.json'
+const BEE_TEMPLATE_URL = 'https://rsrc.getbee.io/api/templates/m-bee'
+//const BEE_BLANK_TEMPLATE_URL = 'http://storage.googleapis.com/pre-bee-app-integration-23fc44e0713f/blank.json'
 const BEEJS_URL = 'https://app-rsrc.getbee.io/plugin/BeePlugin.js'
 const API_AUTH_URL = 'https://auth.getbee.io/apiauth'
 
@@ -202,7 +202,7 @@ const addEvents = () => {
 
 const conf = { authUrl: API_AUTH_URL, beePluginUrl: BEEJS_URL }
 beeTest.getToken(process.env.PLUGIN_CLIENT_ID!, process.env.PLUGIN_CLIENT_SECRET!, conf)
-  .then(() => fetch(new Request(BEE_BLANK_TEMPLATE_URL, { method: 'GET' })))
+  .then(() => fetch(new Request(BEE_TEMPLATE_URL, { method: 'GET' })))
   .then(res => res.json())
   .then(template => {
     const sessionId = getParameterByName('sessionId')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mailupinc/bee-plugin",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "wrapper of bee-plugin",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -1614,7 +1614,7 @@ export interface IBeeConfig {
   onSaveRow?: (jsonfile: unknown, html: string) => void
   onError?: (error: BeePluginError) => void
   onAutoSave?: (json: string) => void
-  onSaveAsTemplate?: (json: Record<string, unknown>) => void
+  onSaveAsTemplate?: (json: string) => void
   onSend?: (html: string) => void
   onChange?: (json: string, detail: BeePluginMessageEditDetail, version: number) => void
   onWarning?: (error: BeePluginError) => void


### PR DESCRIPTION
## Description

- Changed onSaveAsTemplate json parameter type from **Record<String, unknown>** to **string** .
- Changed FileSaved cdn url with a working one.

## Motivation and Context

Close https://github.com/BEE-Plugin/Bee-plugin-official/issues/80

## Usage examples

```js
import BeePLugin from '@mailupinc/bee-plugin'

const template = {....}

const beeConfig :IBeeConfig = {
  uid: 'test1-clientside',
  container: 'bee-plugin-container',
  onSaveAsTemplate: (json) => void save('newsletter-template.json', json),
  ...
}

const beePlugin = new BeePlugin()
beePlugin.getToken().then(() => {
    beePlugin.start(beeConfig, template, '', { shared: false })
})


```


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
