### PR TITLE
chore: added modulesGroups type

### DIFF
--- a/example/integration.ts
+++ b/example/integration.ts
@@ -107,6 +107,44 @@ const beeConfig :IBeeConfig = {
   mergeContents,
   contentDialog,
   contentDefaults,
+  modulesGroups: [
+    {
+      label: 'Text',
+      collapsable: true,
+      collapsedOnLoad: false,
+      modulesNames: [
+        ModuleDescriptorOrderNames.HEADING,
+        ModuleDescriptorOrderNames.PARAGRAPH,
+        ModuleDescriptorOrderNames.LIST
+      ]
+    },
+    {
+      label: 'UI',
+      collapsable: true,
+      collapsedOnLoad: false,
+      modulesNames: [
+        ModuleDescriptorOrderNames.IMAGE,
+        ModuleDescriptorOrderNames.BUTTON,
+        ModuleDescriptorOrderNames.DIVIDER,
+        ModuleDescriptorOrderNames.SPACER,
+        ModuleDescriptorOrderNames.VIDEO,
+        ModuleDescriptorOrderNames.ICONS,
+        ModuleDescriptorOrderNames.HTML,
+        ModuleDescriptorOrderNames.MENU,
+        ModuleDescriptorOrderNames.SOCIAL,
+      ]
+    },
+    {
+      label: 'Others',
+      collapsable: true,
+      collapsedOnLoad: false,
+      modulesNames: [
+       'Dynamics Contents',
+       'Gifs',
+       'Stickers',
+      ]
+    }
+  ],
   defaultModulesOrder: [ 
     'Button',
     'Html',

--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -203,6 +203,13 @@ export const ModuleDescriptorOrderNames = {
   LIST: 'List'
 } as const
 
+export interface IModulesGroups {
+  label: string,
+  collapsable: boolean
+  collapsedOnLoad: boolean
+  modulesNames: ValueOf<typeof ModuleDescriptorOrderNames> | string[]
+}
+
 export interface IPluginModuleHeading {
   type: typeof ModuleTypes.HEADING
   locked?: boolean
@@ -1606,6 +1613,7 @@ export interface IBeeConfig {
   defaultColors?: string[]
   contentDefaults?: ContentDefaults
   defaultModulesOrder?: ValueOf<typeof ModuleDescriptorOrderNames> | string[]
+  modulesGroups?: IModulesGroups[]
   customCss?: string
   workspace?: BeePluginWorkspace
   autosave?: number,

--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -207,7 +207,7 @@ export interface IModulesGroups {
   label: string,
   collapsable: boolean
   collapsedOnLoad: boolean
-  modulesNames: ValueOf<typeof ModuleDescriptorOrderNames> | string[]
+  modulesNames: ValueOf<typeof ModuleDescriptorOrderNames>[] | string[]
 }
 
 export interface IPluginModuleHeading {
@@ -1612,7 +1612,7 @@ export interface IBeeConfig {
   role?: BeePluginRoles,
   defaultColors?: string[]
   contentDefaults?: ContentDefaults
-  defaultModulesOrder?: ValueOf<typeof ModuleDescriptorOrderNames> | string[]
+  defaultModulesOrder?: ValueOf<typeof ModuleDescriptorOrderNames>[] | string[]
   modulesGroups?: IModulesGroups[]
   customCss?: string
   workspace?: BeePluginWorkspace


### PR DESCRIPTION
## Description

Added modulesGroups type on the IBeeConfig 

## Motivation and Context

As described in the doc [here](https://docs.beefree.io/content-tile-grouping/), it's possible to group the sidebar tiles. We added a specific type on the **IBeeConfig** in order to use this feature.

## Usage examples

https://github.com/BEE-Plugin/Bee-plugin-official/blob/83cb13b7e7a7e60695104ef921f55e28b2e3cd83/example/integration.ts#L110-L147

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
