### PR TITLE
fix: added loadRows method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,8 @@ const {
   RELOAD,
   LOAD_WORKSPACE,
   LOAD_STAGE_MODE,
-  LOAD_CONFIG
+  LOAD_CONFIG,
+  LOAD_ROWS
 } = beeActions
 
 class Bee {
@@ -138,6 +139,8 @@ class Bee {
   }
 
   load = (template: Record<string, unknown>) => this.executeAction(LOAD, template)
+
+  loadRows = () => this.executeAction(LOAD_ROWS)
 
   save = () => this.executeAction(SAVE)
 

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -15,7 +15,8 @@ const beeActions = {
   RELOAD: 'reload',
   LOAD_WORKSPACE: 'loadWorkspace',
   LOAD_STAGE_MODE: 'loadStageMode',
-  LOAD_CONFIG: 'loadConfig'
+  LOAD_CONFIG: 'loadConfig',
+  LOAD_ROWS: 'loadRows'
 }
 
 export default beeActions


### PR DESCRIPTION
## Description

Added **loadRows** method

## Motivation and Context

This method triggers the specific contentDialog **loadRows** defined in the Bee Plugin's client config.

## Usage examples

```js
import BeePLugin from '@mailupinc/bee-plugin'

const mergeTags: IMergeTag[] = [{
  name: 'tag 1',
  value: '[tag1]'
}, {
  name: 'tag 2',
  value: '[tag2]'
}]

const beeConfig :IBeeConfig = {
  uid: 'test1-clientside',
  autosave: 15,
  language: 'en-US',
  mergeTags,
}

const template = { page: { ... } }

const beePlugin = new BeePlugin()
beePlugin.start(beeConfig, template, '', { shared: false })
beePlugin.loadRows()
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
