### PR TITLE
feat: Add BeePluginAdvancedPermission["rows"]["toolbar"]["close" | "save"] type.

### DIFF
--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -855,6 +855,8 @@ export type BeePluginAdvancedPermission = RecursivePartial<{
     hideOnMobile: AdvancedSettingsShowLocked
     rowLayout: AdvancedSettingsShowLocked
     toolbar: {
+      close: AdvancedSettingsShowLocked
+      save: AdvancedSettingsShowLocked
       editSyncedRow: AdvancedSettingsShowLocked
     }
   },


### PR DESCRIPTION
Add BeePluginAdvancedPermission["rows"]["toolbar"]["close" | "save"] type.

[BEE's documentation](https://docs.beefree.io/advanced-permissions/#:~:text=toolbar%3A%20%7B%0A%20%20%20%20%20%20%20%20close%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20show%3A%20true%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20locked%3A%20false%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20save%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20show%3A%20true%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20locked%3A%20false%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20editSyncedRow%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20show%3A%20true%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20locked%3A%20false%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%7D%2C) shows support for advanced toolbar permissions for `close` and `save` actions.