### PR TITLE
fix: added missing contentDialog externalContentURLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.1.2-fix-108-external-content-urls.0](https://github.com/BEE-Plugin/Bee-plugin-official/compare/v2.1.1...v2.1.2-fix-108-external-content-urls.0) (2023-04-12)
+
+
+### Bug Fixes
+
+* added missing contentDialog externalContentURLs ([31db83c](https://github.com/BEE-Plugin/Bee-plugin-official/commit/31db83c46c05c6ef6462f9277ca10e47886ff4d4))
+
 ### [2.1.1](https://github.com/BEE-Plugin/Bee-plugin-official/compare/v2.1.0...v2.1.1) (2023-03-23)
 
 ### [2.1.1](https://github.com/BEE-Plugin/Bee-plugin-official/compare/v2.1.0...v2.1.1) (2023-03-23)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mailupinc/bee-plugin",
-  "version": "2.1.1",
+  "version": "2.1.2-fix-108-external-content-urls.0",
   "description": "wrapper of bee-plugin",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -1675,6 +1675,10 @@ export type BeeContentDialogs = {
   onEditRow?: {
     label?: string
     handler: BeePluginContentDialogHandler<IRefreshSavedRow, undefined, unknown>
+  },
+  externalContentURLs?: {
+    label?: string
+    handler: BeePluginContentDialogHandler<CustomRowConfiguration>
   }
 }
 


### PR DESCRIPTION
## Description

Added externalContentURLS contentDialog type definition

## Motivation and Context

Close https://github.com/BEE-Plugin/Bee-plugin-official/issues/108

## Usage examples

https://docs.beefree.io/extending-custom-rows-with-content-dialog/

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
