### PR TITLE
Chore/start method parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.1.6-chore-start-method-parameters.0](https://github.com/BEE-Plugin/Bee-plugin-official/compare/v2.1.5...v2.1.6-chore-start-method-parameters.0) (2023-06-14)
+
 ### [2.1.5](https://github.com/BEE-Plugin/Bee-plugin-official/compare/v2.1.5-fix-bugfixing.1...v2.1.5) (2023-05-19)
 
 ### [2.1.5-fix-bugfixing.1](https://github.com/BEE-Plugin/Bee-plugin-official/compare/v2.1.5-fix-bugfixing.0...v2.1.5-fix-bugfixing.1) (2023-05-15)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mailupinc/bee-plugin",
-  "version": "2.1.5",
+  "version": "2.1.6-chore-start-method-parameters.0",
   "description": "wrapper of bee-plugin",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,13 +84,13 @@ class Bee {
 
   start = (
     config: IBeeConfig,
-    template: IEntityContentJson,
+    template: IEntityContentJson | object, //user can pass an empty object in some specific cases
     bucketDir?: string, 
     options?: IBeeOptions
   ) => {
     const { bee, token } = this    
     return pipe(
-      eitherCheckStartParams(config, template, token),
+      eitherCheckStartParams(config, token),
       E.fold(
         ({ message }) => new Promise(reject => reject(message)),
         () => new Promise(resolve => {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,12 +1,11 @@
 import * as E from 'fp-ts/lib/Either'
 import { pipe } from 'fp-ts/lib/function'
-import { IBeeConfig, IEntityContentJson, IToken } from '../types/bee'
+import { IBeeConfig, IToken } from '../types/bee'
 import beeActions from './Constants'
 
 const eitherHasConfig = (config: IBeeConfig) => !config ? E.left(new Error('Config is missing')) : E.right(config)
 const eitherHasSessionId = (sessionId: string) => !sessionId ? E.left(new Error('SessionId is missing')) : E.right(sessionId)
 const eitherHasToken = (token: IToken) => !token || !token.access_token ? E.left(new Error('Malformed or undefined token, call getToken() or pass your token on new BEE')) : E.right(token)
-const eitherHasTemplate = (template: IEntityContentJson) => !template ? E.left(new Error('template is missing')) : E.right(template)
 
 export const eitherCheckJoinParams = (config: IBeeConfig, sessionId: string, token: IToken) => pipe(
     eitherHasSessionId(sessionId),
@@ -14,10 +13,9 @@ export const eitherCheckJoinParams = (config: IBeeConfig, sessionId: string, tok
     E.chain(() => eitherHasToken(token))
 )
 
-export const eitherCheckStartParams = (config: IBeeConfig, template: IEntityContentJson, token: IToken) => pipe(
+export const eitherCheckStartParams = (config: IBeeConfig, token: IToken) => pipe(
     eitherHasConfig(config),
     E.chain(() => eitherHasToken(token)),
-    E.chain(() => eitherHasTemplate(template))
 )
 
 const eitherBeeInstanceExist = (instance: any) => !instance ? E.left(new Error('Bee is not started')) : E.right(instance)


### PR DESCRIPTION
## Description

It is possible to call the start method with an empty object as a template

## Motivation and Context

Meet documentation

## Usage examples

```js
import BeePLugin from '@mailupinc/bee-plugin'

const beePlugin = new BeePlugin()
const config: IBeeConfig = {
...
}
beePlugin.start(config, {})
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
