### PR TITLE
Add onSelectElement callback to IBeeConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [11.4.0](https://github.com/BeefreeSDK/beefree-sdk-npm-official/compare/v11.3.0...v11.4.0) (2026-03-31)
+
+
+### Features
+
+* add onSelectElement callback to IBeeConfig for element selection handling ([97befee](https://github.com/BeefreeSDK/beefree-sdk-npm-official/commit/97befee0ccab355af1cc7dae8ab45478c745a162))
+
 ### [11.3.0](https://github.com/BeefreeSDK/beefree-sdk-npm-official/compare/v11.2.3...v11.3.0) (2026-03-26)
 
 

--- a/example/integration.ts
+++ b/example/integration.ts
@@ -275,6 +275,7 @@ const beeConfig :IBeeConfig = {
     console.log(`${new Date().toISOString()} autosaving...,`, jsonFile)
     window.localStorage.setItem('newsletter.autosave', jsonFile)
   },
+  onSelectElement: ({type, uuid}) => console.log(`*** [integration] user is selecting a ${type} with uuid ${uuid}`),
   onSend: (htmlFile) => console.log('onSend', htmlFile),
   onError: (errorMessage) => console.log('onError ', errorMessage),
   onChange: (msg, response) => console.warn('*** [integration] (OnChange) message --> ', msg, response),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beefree.io/sdk",
-  "version": "11.3.0",
+  "version": "11.4.0",
   "description": "wrapper of BeefreeSDK",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -3058,6 +3058,11 @@ export type DebugConfig = {
 
 export type IBeeContainer = string | HTMLElement
 
+export type SelectedElement = {
+  type: 'module' | 'row'
+  uuid: string
+}
+
 export interface IBeeConfig {
   container: IBeeContainer
   uid?: string
@@ -3132,6 +3137,7 @@ export interface IBeeConfig {
   onLoadWorkspace?: (worspaceType: LoadWorkspaceOptions) => void
   onViewChange?: (view: ViewTypes) => void
   onPreviewChange?: (preview: onChangePreviewControlArgs<ValueOf<typeof PREVIEW_CONTROL>>) => void
+  onSelectElement?: (selectedElement: SelectedElement) => void
   commentingFiltersOff?: boolean
   logLevel?: number
   titleDefaultConfig?: {


### PR DESCRIPTION
## Description

Adds SelectElement callback to IBeeConfig 

## Motivation and Context
This callback was introduced to expose selected element uuid and type to the hosting application. This is meant to be used with agentic workflows in conjunction with the beefree sdk mcp.

## Types of changes

New feature (non-breaking change which adds functionality)
