### PR TITLE
Add ai addon types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [11.6.0](https://github.com/BeefreeSDK/beefree-sdk-npm-official/compare/v11.5.1...v11.6.0) (2026-07-17)
+
+
+### Features
+
+* add ai addon type and new on info callback shape ([2ccc869](https://github.com/BeefreeSDK/beefree-sdk-npm-official/commit/2ccc8697b13e985f3de18f856793e90b77f5bc58))
+
 ### [11.5.1](https://github.com/BeefreeSDK/beefree-sdk-npm-official/compare/v11.5.0...v11.5.1) (2026-06-12)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beefree.io/sdk",
-  "version": "11.5.1",
+  "version": "11.6.0",
   "description": "wrapper of BeefreeSDK",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -138,6 +138,7 @@ export enum BeePluginErrorCodes {
   LOCKED_ROW_CLICKED = 1300,
   LOCKED_MODULE_CLICKED = 1310,
   WORKSPACE_NOT_AVAILABLE = 1002,
+  AI_AGENT_MESSAGES_CHANGED = 1010,
   FEATURE_NOT_AVAILABLE_FOR_PLAN = 1704,
   FEATURE_NOT_AVAILABLE_FOR_WORKSPACE = 1707,
   GENERIC_BUMP_ERROR = 2000,
@@ -243,7 +244,8 @@ export type BeePluginError = {
 export enum OnInfoDetailHandle {
   AI_INTEGRATION = 'ai-integration',
   AI_ALT_TEXT = 'ai-alt-text',
-  AI_IMAGE_GENERATION = 'ai-image-generation'
+  AI_IMAGE_GENERATION = 'ai-image-generation',
+  AI_AGENT = 'ai-agent'
 }
 
 export type AiIntegrationErrorDetail = {
@@ -274,10 +276,15 @@ export type AiImageGenerationErrorDetail = {
   consumedImages: number
 }
 
+export type AiAgentMessagesChangedDetail = {
+  handle: OnInfoDetailHandle.AI_AGENT
+  messages: unknown[]
+}
+
 export type BeePluginInfo = {
   code: BeePluginErrorCodes
   message: string
-  detail: AiIntegrationErrorDetail | AiAltTextErrorDetail | AiImageGenerationErrorDetail
+  detail: AiIntegrationErrorDetail | AiAltTextErrorDetail | AiImageGenerationErrorDetail | AiAgentMessagesChangedDetail
 }
 
 type KebabCSSProperties = KebabKeys<CSS.Properties>
@@ -3003,6 +3010,22 @@ export interface AddOnImageGenerationAI {
   }
 }
 
+export interface AddOnAiAgent {
+  id: 'ai-agent'
+  enabled?: boolean
+  settings: {
+    /**
+     * Chat history seed shown when the panel opens. Pair with the
+     * `onInfo` AI_AGENT_MESSAGES_CHANGED event to persist and restore
+     * conversations. Messages follow the vercel ai-sdk `UIMessage` shape.
+     */
+    initialMessages?: unknown[]
+    loadingPhrases?: string[]
+    maxIterations?: number
+    systemPrompt?: string
+  }
+}
+
 export interface AddOnFileManager {
   id: string
   ctaLabel?: string
@@ -3021,7 +3044,7 @@ interface BaseAddon {
   openOnDrop?: boolean
 }
 
-export type AddOn = BaseAddon | AddOnPartner | AddOnOpenAI | AddOnAltTextAI | AddOnImageGenerationAI | AddOnFileManager
+export type AddOn = BaseAddon | AddOnPartner | AddOnOpenAI | AddOnAltTextAI | AddOnImageGenerationAI | AddOnFileManager | AddOnAiAgent
 
 export interface Translations {
   [key: string]: string | Translations;


### PR DESCRIPTION
## Description
Adds TypeScript definitions for the AI Agent addon (currently in closed beta):

## Motivation and Context
The AI Agent addon  is configurable via addOns and emits its chat history through onInfo so integrators can persist and restore conversations.

## Usage examples
```
import BeefreeSDK, { OnInfoDetailHandle, BeePluginErrorCodes } from '@beefree.io/sdk'

const beeConfig = {
  // ...
  addOns: [{
    id: 'ai-agent',
    settings: {
      initialMessages: restoredMessages,
    },
  }],
  onInfo: (info) => {
    if (info.code === BeePluginErrorCodes.AI_AGENT_MESSAGES_CHANGED
      && info.detail.handle === OnInfoDetailHandle.AI_AGENT) {
      persist(info.detail.messages)
    }
  },
}
```
## How Has This Been Tested?
yarn tsc passes. Verified the shapes against the addon implementation.

## Types of changes
New feature (non-breaking change which adds functionality)
