### PR TITLE
Fix/advanced permissions custom head tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [11.6.1-fix-advanced-permissions-custom-head-tags.0](https://github.com/BeefreeSDK/beefree-sdk-npm-official/compare/v11.6.0...v11.6.1-fix-advanced-permissions-custom-head-tags.0) (2026-07-24)
+
+
+### Bug Fixes
+
+* missing customHeadTags property in advancedPermissions type ([dddaf95](https://github.com/BeefreeSDK/beefree-sdk-npm-official/commit/dddaf9535b3cf3034d6e6b7a0bd8127254c7811d))
+
 ## [11.6.0](https://github.com/BeefreeSDK/beefree-sdk-npm-official/compare/v11.5.1...v11.6.0) (2026-07-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [11.6.1](https://github.com/BeefreeSDK/beefree-sdk-npm-official/compare/v11.6.1-fix-advanced-permissions-custom-head-tags.0...v11.6.1) (2026-07-24)
+
 ### [11.6.1-fix-advanced-permissions-custom-head-tags.0](https://github.com/BeefreeSDK/beefree-sdk-npm-official/compare/v11.6.0...v11.6.1-fix-advanced-permissions-custom-head-tags.0) (2026-07-24)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beefree.io/sdk",
-  "version": "11.6.1-fix-advanced-permissions-custom-head-tags.0",
+  "version": "11.6.1",
   "description": "wrapper of BeefreeSDK",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beefree.io/sdk",
-  "version": "11.6.0",
+  "version": "11.6.1-fix-advanced-permissions-custom-head-tags.0",
   "description": "wrapper of BeefreeSDK",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -1578,6 +1578,7 @@ export type BeePluginAdvancedPermission = RecursivePartial<{
     defaultFontFamily: AdvancedSettingsShowLocked
     linkColor: AdvancedSettingsShowLocked
     containerBackgroundImage: AdvancedSettingsShowLocked
+    customHeadTags: AdvancedSettingsShowLocked
   }
   columns: {
     behaviors: {


### PR DESCRIPTION
## Description

Add `customHeadTags` to `advancedPermissions` type

## Motivation and Context

Missing `customHeadTags` TS property

